### PR TITLE
Fix Husky pre-commit hook: add zsh shebang

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
+#!/usr/bin/env zsh
 eval "$(mise activate zsh)"
 gitleaks protect --staged --verbose
 npx lint-staged


### PR DESCRIPTION
## Summary
- Adds `#!/usr/bin/env zsh` shebang to `.husky/pre-commit`
- Husky runs hooks under bash by default, but the hook uses `mise activate zsh` which outputs zsh-specific syntax, causing parse errors
- The shebang tells Husky to use zsh, matching the `mise activate` call

## Test plan
- [x] Ran the pre-commit hook directly — gitleaks, lint-staged, typecheck, and all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)