### PR TITLE
Fix Dependabot duplicate PRs and Husky pre-commit hook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/packages/*"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
-#!/usr/bin/env zsh
-eval "$(mise activate zsh)"
+#!/usr/bin/env sh
+eval "$(mise activate bash)"
 gitleaks protect --staged --verbose
 npx lint-staged
 pnpm -r run typecheck


### PR DESCRIPTION
## Summary
- Remove `/packages/*` from Dependabot `directories` config — the root `pnpm-lock.yaml` already covers all workspace packages, so per-package directories were causing duplicate PRs (e.g. 4 PRs for a single TypeScript bump)
- Fix pre-commit hook to use `mise activate bash` instead of `mise activate zsh`, since Husky's wrapper script (`sh -e "$s"`) forces `sh` regardless of the hook's shebang

## Test plan
- [ ] Verify next Dependabot run produces grouped PRs (one per group) instead of duplicates per package
- [ ] Verify `git commit` triggers pre-commit hook successfully (gitleaks, lint-staged, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)