### PR TITLE
Fix doc inaccuracies and add package-level CLAUDE.md files

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -112,7 +112,7 @@ Corrections are preserved alongside original decisions for the agent to learn fr
 { "due_at": "2026-04-01T09:00:00Z", "description": "Call the plumber" }
 
 // tag — one decision per tag
-{ "tag": "urgent" }
+{ "label": "urgent" }
 ```
 
 **Categories** are freeform strings, not a fixed enum. The agent is instructed to prefer a seed list of common categories but can create new ones when nothing fits. The proactive reviewer consolidates duplicates over time.
@@ -211,6 +211,7 @@ The MCP server exposes these tools via the MCP protocol. Authenticated with the 
 | `list_decisions`      | Query decisions (e.g., pending reminders, low-confidence)                                                                      |
 | `create_group`        | Create/update thought groups                                                                                                   |
 | `create_notification` | Surface an insight/reminder/suggestion to the user                                                                             |
+| `set_session_title`   | Set or update the title of a chat session                                                                                      |
 
 `capture_thought` is atomic — it accepts thought text, a pre-computed embedding, and an array of decisions, inserts the thought, and inserts all decisions in a single database transaction. Returns the created IDs so the agent can reference specific decisions later:
 
@@ -404,7 +405,7 @@ Once an embedding dimension (1536) is chosen, changing it requires re-embedding 
 
 ```typescript
 interface LLMProvider {
-  chat(messages: Message[], tools?: Tool[]): Promise<LLMResponse>;
+  chat(messages: LLMMessage[], tools: ToolDefinition[]): Promise<LLMResponse>;
 }
 ```
 
@@ -421,7 +422,7 @@ OpenAI first (gpt-4o for reasoning, gpt-4o-mini as an option for cheaper calls l
 
 ## Project Structure
 
-Monorepo with npm workspaces. Shared TypeScript types between web app and agent.
+Monorepo with pnpm workspaces. Shared TypeScript types between web app and agent.
 
 ```
 open-brain/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Single test file: `pnpm -C packages/agent exec vitest run src/some-file.test.ts`
 - **`packages/shared`** — TypeScript types shared across packages (database entities, decision types, review status). No runtime code.
 - **`packages/web`** — React 19 + Vite frontend. Tailwind 4, React Router 7, TanStack Query. Path alias `@/*` maps to `src/*`.
 - **`packages/agent`** — Node.js agent process. Uses OpenAI SDK (gpt-4o) with ReAct loop pattern, consuming tools from the MCP server. Runs scheduled jobs via node-cron.
-- **`supabase/functions/mcp`** — Deno Edge Function exposing 8 MCP tools (Hono framework, Zod validation). Tools: `capture_thought`, `update_thought`, `search_thoughts`, `list_thoughts`, `create_decision`, `update_decision`, `list_decisions`, `create_notification`.
+- **`supabase/functions/mcp`** — Deno Edge Function exposing 10 MCP tools (Hono framework, Zod validation). Tools: `capture_thought`, `update_thought`, `search_thoughts`, `list_thoughts`, `create_decision`, `update_decision`, `list_decisions`, `create_group`, `create_notification`, `set_session_title`.
 
 ### Communication Pattern
 

--- a/packages/agent/CLAUDE.md
+++ b/packages/agent/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+pnpm dev                  # Start agent with tsx watch (auto-reload)
+pnpm build                # TypeScript compilation to dist/
+pnpm typecheck            # Type-check only (tsc -b)
+pnpm test                 # Run all tests once (vitest run)
+pnpm test:watch           # Watch mode
+```
+
+Single test file: `pnpm exec vitest run src/__tests__/some-file.test.ts`
+
+From monorepo root: `task test:agent` or `pnpm -C packages/agent exec vitest run src/some-file.test.ts`
+
+## Architecture
+
+### ReAct Loop (`react-loop-executor.ts`)
+
+The core processing engine. Each user message triggers a loop (max 10 rounds):
+
+1. Send messages + tool definitions to LLM
+2. If LLM returns `finish_reason="stop"` -> return response
+3. If `tool_calls` exist: parse args, inject embeddings/session context, execute via MCP, append results to history
+4. Continue to next round
+
+Key mechanisms:
+- **Schema rewriting**: Infrastructure params (`session_id`, `embedding`) are hidden from the LLM. The executor auto-injects them via `argInjections` and converts text fields to embeddings before calling MCP tools.
+- **Tool filtering**: `toolFilter: Set<string>` restricts which tools the LLM can see (used by proactive reviewer to limit to review-only tools).
+- **Error recovery**: Tool failures are serialized to JSON and passed back to the LLM as tool results, letting it reason about and recover from errors.
+
+### Message Processing Flow
+
+1. **Startup** (`startup.ts`): `recoverUnanswered()` finds sessions where the last message is from the user with no assistant response. Processes them chronologically before subscribing to Realtime.
+2. **Realtime subscription** (`index.ts`): Listens for INSERT events on `chat_messages`. On new user message, acquires session lock and runs ReAct loop.
+3. **Context building** (`chat-context-loader.ts`): Loads message history, session metadata, and past corrections. Builds dynamic system prompt with current date/time and correction feedback from `prompts/system.md`.
+
+### Session Locking (`session-lock.ts`)
+
+Per-session mutex using Promise chaining. Sequential within a session, concurrent across sessions. Prevents race conditions when multiple messages arrive for the same session.
+
+### Scheduler (`scheduler.ts`)
+
+Two cron jobs:
+- **Reminder checker** (every 1 min): Pure SQL via RPC `get_due_reminders()`. Finds due reminders and creates notification records. No LLM calls.
+- **Proactive reviewer** (every 6 hrs): Two-pass — SQL selects candidates (low-confidence decisions < 0.7, corrected decisions, max 50), then LLM reclassifies/groups/generates insights using a filtered tool set.
+
+### MCP Client (`mcp-client.ts`)
+
+Thin JSON-RPC 2.0 client over HTTP to the Supabase Edge Function. Methods: `initialize()`, `listTools()`, `callTool(name, args)`. Protocol version `2025-03-26`.
+
+### LLM Provider (`llm-provider.ts`)
+
+Wraps OpenAI SDK. Two capabilities: chat completions (gpt-4o) and embeddings (text-embedding-3-small, 1536 dims). Abstracts message formatting and tool serialization.
+
+## Testing Patterns
+
+- Vitest with `globals: true` and `restoreMocks: true` (auto-cleanup)
+- All external dependencies mocked with `vi.mock()` / `vi.fn()`
+- Supabase mocked with chainable builders (`.from().select().eq().order()` returns mock data)
+- Tests cover: ReAct loop rounds, tool execution, embedding injection, argument injection, startup recovery, scheduler logic, context loading

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+pnpm dev                  # Vite dev server
+pnpm build                # Type-check + Vite build (tsc -b && vite build)
+pnpm typecheck            # Type-check only (tsc -b)
+pnpm test                 # Run all tests once (vitest run)
+pnpm test:watch           # Watch mode
+```
+
+From monorepo root: `task test:web`
+
+## Architecture
+
+### Routing (React Router 7)
+
+Three routes in `App.tsx`:
+- `/login` -> `LoginView` (public)
+- `/` -> `ChatShell` (wrapped in `ProtectedRoute`)
+- `*` -> redirects to `/`
+
+`ProtectedRoute` checks `useAuth()` and redirects unauthenticated users to `/login`.
+
+### State Management
+
+**TanStack Query** for all server state. Query keys:
+- `["chat_sessions"]` — session list
+- `["chat_messages", sessionId]` — messages for a session
+- `"thought_decisions"` — decision review data
+- `"notifications"` — notification list
+
+**React Context** for UI state:
+- `AuthProvider` (`use-auth.tsx`) — Supabase session, `signIn()`, `signOut()`
+- `SessionProvider` (`use-sessions.tsx`) — currently selected chat session
+
+**Mutations** use optimistic updates: create temporary entries (e.g., `"optimistic-${Date.now()}"`), rollback on error via `onError` with saved previous state.
+
+### Realtime Subscriptions
+
+Hooks subscribe to Supabase Realtime channels for live updates:
+- `useMessages` subscribes to `messages:${sessionId}` channel (INSERT events on `chat_messages`)
+- `useNotifications` subscribes to `notifications-realtime` channel
+- Both update the TanStack Query cache on new events and deduplicate against existing data
+- Channels are cleaned up on unmount via `useEffect` return
+
+### Styling
+
+**Tailwind CSS 4** with Material Design 3 dark theme defined in `src/index.css` via `@theme`. Key tokens: `surface`, `primary`, `on-surface`, `secondary`, `tertiary`, `error` with MD3 elevation tiers (lowest/low/container/high/highest).
+
+Fonts: Inter (body), Space Grotesk (headlines) — loaded from Google Fonts.
+
+Utility: `cn()` in `lib/utils.ts` (clsx + tailwind-merge) for conditional class merging.
+
+`DESIGN.md` contains the full visual design system ("Obsidian Intelligence Framework") with rules for surface layering, typography, elevation, and component styling. Consult it when building or modifying UI components.
+
+### Component Organization
+
+- **`components/ui/`** — Reusable primitives (Button, Input, Label) using CVA for variants
+- **`components/`** — Feature components (ChatView, ProtectedRoute)
+- **`views/`** — Page-level containers (ChatShell, LoginView, DecisionReviewView, NotificationsView)
+- **`hooks/`** — Data hooks wrapping TanStack Query + Supabase calls
+- **`lib/`** — Supabase client init, utilities
+
+### Path Alias
+
+`@/*` maps to `src/*` (configured in both `tsconfig.json` and `vite.config.ts`).
+
+## Testing Patterns
+
+- Vitest with jsdom environment, `globals: true`
+- Setup file: `src/test-setup.ts` (registers jest-dom matchers, mocks `scrollIntoView`)
+- Supabase mocked with `vi.mock("@/lib/supabase")` — chainable query builders
+- Auth state initialized via `setupAuthMock()` helper in tests
+- Interactive elements have `data-testid` attributes
+- Uses `@testing-library/react` for rendering + queries, `@testing-library/user-event` for interactions, `waitFor()` for async assertions
+
+### Types
+
+All domain types imported from `@backup-brain/shared` (ChatSession, ChatMessage, Notification, ThoughtDecision, etc.). No local type duplication.

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -1,0 +1,82 @@
+# Design System: The Obsidian Intelligence Framework
+
+## 1. Overview & Creative North Star
+**The Creative North Star: "The Digital Synapse"**
+This design system moves away from the static, "boxed-in" feel of traditional utility apps to create a high-end, editorial experience that feels like a seamless extension of the user’s own mind. We are building a "Digital Synapse"—a space that is moody, deep, and hyper-organized, echoing the sophisticated environment of a modern developer’s IDE but softened for a premium consumer experience.
+
+By leaning into **Tonal Layering** and **Intentional Asymmetry**, we break the "template" look. Layouts should prioritize breathing room and content hierarchy over structural containers. The goal is to make the user feel like they are interacting with a living, breathing archive rather than a flat database.
+
+---
+
+## 2. Colors & Surface Philosophy
+The palette is rooted in deep charcoal and slate, designed to reduce cognitive load and provide a high-contrast stage for "electric" primary actions.
+
+### The "No-Line" Rule
+**Explicit Instruction:** Designers are prohibited from using 1px solid borders to define sections or cards. Structure must be achieved exclusively through:
+1.  **Background Color Shifts:** Using `surface-container-low` (#191b22) against the main `surface` (#111319).
+2.  **Negative Space:** Utilizing the `Spacing Scale` (e.g., `8` or `10`) to separate conceptual blocks.
+
+### Surface Hierarchy & Nesting
+Treat the UI as a series of physical layers. Use the `surface-container` tiers to create "nested" depth:
+*   **Base Layer:** `surface` (#111319) - The primary canvas.
+*   **Recessed Content:** `surface-container-lowest` (#0c0e14) - For secondary search bars or input areas.
+*   **Primary Containers:** `surface-container-low` (#191b22) - For the main feed or chat bubbles.
+*   **Elevated Details:** `surface-container-high` (#282a30) - For active decision cards or overlays.
+
+### The "Glass & Gradient" Rule
+To elevate beyond a standard dark theme, use Glassmorphism for floating elements (like the bottom navigation or compact headers). Apply `surface-variant` (#33343b) at 60% opacity with a `20px` backdrop-blur. 
+*   **Signature Texture:** Main CTAs should not be flat. Apply a subtle linear gradient from `primary` (#adc6ff) to `primary-container` (#4d8eff) at a 135-degree angle to give the button "soul" and a slight inner glow.
+
+---
+
+## 3. Typography: Editorial Precision
+The system pairs the technical rigidity of `Inter` with the high-impact, geometric personality of `Space Grotesk`.
+
+*   **Display & Headlines (`Space Grotesk`):** Used for "Big Ideas"—memory summaries, dates, or AI-generated insights. The large scale (`display-sm` to `headline-lg`) provides an authoritative, editorial feel.
+*   **Body & Labels (`Inter`):** Optimized for long-form reading of memories and chat logs. Use `body-md` for general text and `label-sm` for metadata (timestamps, category tags).
+*   **Hierarchy Note:** Always pair a `headline-sm` in `on-surface` (#e2e2eb) with a `label-md` in `on-surface-variant` (#c2c6d6) to create a clear, professional contrast between "Title" and "Context."
+
+---
+
+## 4. Elevation & Depth: Tonal Layering
+Traditional shadows are too heavy for a "Moody IDE" aesthetic. We use light and tone to imply height.
+
+*   **The Layering Principle:** Instead of a shadow, place a `surface-container-low` card on top of a `surface` background. The slight shift from #111319 to #191b22 provides a sophisticated, "flat-depth" look.
+*   **Ambient Shadows:** For floating Modals only, use a large, diffused shadow: `0px 20px 40px rgba(0, 0, 0, 0.4)`. The shadow color is not black, but a deeply desaturated version of the background.
+*   **The "Ghost Border":** If accessibility requires a stroke (e.g., in high-sunlight environments), use `outline-variant` (#424754) at **15% opacity**. It should be felt, not seen.
+
+---
+
+## 5. Components
+
+### Cards & Decision Elements
+*   **Rule:** No dividers. Use a `1.4rem` (`spacing.4`) vertical gap between items.
+*   **Decision Cards:** Use `surface-container-high`. Status indicators (Green/Yellow/Red/Purple) should be styled as 4px wide vertical "pills" on the far left edge of the card, rather than large icons, to maintain professional minimalism.
+
+### Chat Bubbles
+*   **AI Response:** `surface-container-low` with a subtle `primary` glow (2px inner shadow).
+*   **User Input:** `surface-container-highest` with `8px` (`DEFAULT`) rounded corners.
+
+### Interactive Elements
+*   **Primary Action Button:** Gradient-filled (`primary` to `primary-container`), `8px` rounded corners, `1.2rem` horizontal padding.
+*   **Chips:** Use `surface-container-high` for unselected and `primary` for selected. Avoid borders; use color weight to signify state.
+*   **Input Fields:** `surface-container-lowest`. On focus, change the background to `surface-container-low` and add a `primary` ghost-border (20% opacity).
+
+### Specialized Components
+*   **The Synapse Header:** A compact, fixed top-bar using Glassmorphism. The title uses `title-sm` in `Space Grotesk`.
+*   **Memory Badges:** Tiny, high-contrast dots using `tertiary` (#ffb786) to indicate "Unread AI Insights."
+
+---
+
+## 6. Do’s and Don’ts
+
+### Do
+*   **Do** use asymmetrical spacing. A card might have `1.4rem` top padding and `1.7rem` bottom padding to create a sense of movement.
+*   **Do** use `on-surface-variant` (#c2c6d6) for all secondary text to maintain the "moody" atmosphere.
+*   **Do** utilize `backdrop-filter: blur(12px)` on all overlay surfaces to keep the user grounded in their current context.
+
+### Don’t
+*   **Don’t** use pure white (#FFFFFF). It breaks the dark-mode immersion. Always stick to `on-surface` (#e2e2eb).
+*   **Don’t** use standard 1px dividers. If you feel the need for a line, your spacing or background tonal shifts are not strong enough.
+*   **Don’t** use sharp 0px corners. This is an assistant app; it should feel technical (IDE-like) but approachable. Stick strictly to the `8px` (`DEFAULT`) and `12px` (`md`) radius tokens.
+*   **Don’t** clutter the compact header. It should contain a maximum of three elements: Brand/Page Title, Memory Icon, and Search.


### PR DESCRIPTION
## Summary
- Fix 5 factual errors in CLAUDE.md and ARCHITECTURE.md: MCP tool count (8→10), tag value shape (`tag`→`label`), `LLMProvider` interface signature, missing `set_session_title` tool in MCP table, and npm→pnpm workspaces
- Add `packages/agent/CLAUDE.md` with ReAct loop, session locking, scheduler, and testing details
- Add `packages/web/CLAUDE.md` with routing, state management, realtime, styling, and testing details
- Add `packages/web/DESIGN.md` with the Obsidian Intelligence visual design system

## Test plan
- [ ] Verify CLAUDE.md tool list matches `supabase/functions/mcp/index.ts` tool definitions
- [ ] Verify ARCHITECTURE.md `TagValue` shape matches `packages/shared/src/types.ts`
- [ ] Verify `LLMProvider` interface matches `packages/agent/src/llm-provider.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)