### PR TITLE
Enforce decision value schemas at MCP boundary

### DIFF
--- a/packages/agent/prompts/system.md
+++ b/packages/agent/prompts/system.md
@@ -21,7 +21,7 @@ Every decision you make (classification, entity, reminder, tag) must include:
   - classification: `{ "category": "<category name>" }`
   - entity: `{ "name": "<entity name>", "type": "<person|place|thing|organization>" }`
   - reminder: `{ "due_at": "<ISO 8601 datetime>", "description": "<what to remind>" }`
-  - tag: `{ "tag": "<tag name>" }`
+  - tag: `{ "label": "<tag name>" }`
 - A **confidence** score between 0 and 1
 - A **reasoning** string explaining why you made that choice
 

--- a/packages/agent/src/react-loop-executor.ts
+++ b/packages/agent/src/react-loop-executor.ts
@@ -61,8 +61,8 @@ function rewriteToolsForLLM(tools: ToolDefinition[]): ToolDefinition[] {
                     description:
                       'Decision payload. For classification: {"category": "..."}, ' +
                       'for entity: {"name": "...", "type": "..."}, ' +
-                      'for reminder: {"due_at": "ISO date", "message": "..."}, ' +
-                      'for tag: {"tag": "..."}',
+                      'for reminder: {"due_at": "ISO date", "description": "..."}, ' +
+                      'for tag: {"label": "..."}',
                   },
                   confidence: { type: "number", description: "0-1" },
                   reasoning: { type: "string" },

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
-import { z, ZodObject, ZodRawShape } from "zod";
+import { z, ZodObject, ZodRawShape, ZodType } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 // ---------------------------------------------------------------------------
@@ -16,11 +16,11 @@ const supabase: SupabaseClient = createClient(
 // Tool registry
 // ---------------------------------------------------------------------------
 
-interface McpTool<S extends ZodRawShape = ZodRawShape> {
+interface McpTool<T extends ZodType = ZodType> {
   name: string;
   description: string;
-  schema: ZodObject<S>;
-  handler: (args: z.infer<ZodObject<S>>) => Promise<{
+  schema: T;
+  handler: (args: z.infer<T>) => Promise<{
     content: { type: "text"; text: string }[];
     isError?: boolean;
   }>;
@@ -29,11 +29,14 @@ interface McpTool<S extends ZodRawShape = ZodRawShape> {
 // deno-lint-ignore no-explicit-any
 const tools: McpTool<any>[] = [];
 
-function tool<S extends ZodRawShape>(
+function tool<T extends ZodType>(
   name: string,
   description: string,
-  schema: ZodObject<S>,
-  handler: McpTool<S>["handler"]
+  schema: T,
+  handler: (args: z.infer<T>) => Promise<{
+    content: { type: "text"; text: string }[];
+    isError?: boolean;
+  }>
 ) {
   tools.push({ name, description, schema, handler });
 }
@@ -50,6 +53,62 @@ function err(message: string) {
     isError: true as const,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Decision value schemas — discriminated by decision_type
+// ---------------------------------------------------------------------------
+
+const decisionValueSchemas = {
+  classification: z.object({ category: z.string() }),
+  entity: z.object({ name: z.string(), type: z.string() }),
+  reminder: z.object({ due_at: z.string(), description: z.string() }),
+  tag: z.object({ label: z.string() }),
+} as const;
+
+type DecisionType = keyof typeof decisionValueSchemas;
+
+function formatShape(type: DecisionType): string {
+  const shapes: Record<DecisionType, string> = {
+    classification: "{ category: string }",
+    entity: "{ name: string, type: string }",
+    reminder: "{ due_at: string, description: string }",
+    tag: "{ label: string }",
+  };
+  return shapes[type];
+}
+
+function refineDecisionValue(
+  entry: { decision_type: DecisionType; value: Record<string, unknown> },
+  ctx: z.RefinementCtx
+) {
+  const schema = decisionValueSchemas[entry.decision_type];
+  const result = schema.safeParse(entry.value);
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      ctx.addIssue({
+        ...issue,
+        path: ["value", ...issue.path],
+        message: `Invalid value for ${entry.decision_type}: ${issue.message}. Expected shape: ${formatShape(entry.decision_type)}`,
+      });
+    }
+  }
+}
+
+const decisionEntrySchema = z
+  .object({
+    decision_type: z.enum(["classification", "entity", "reminder", "tag"]),
+    value: z
+      .record(z.unknown())
+      .describe("Decision value (shape depends on decision_type)"),
+    confidence: z.number().min(0).max(1),
+    reasoning: z.string(),
+  })
+  .superRefine((entry, ctx) =>
+    refineDecisionValue(
+      entry as { decision_type: DecisionType; value: Record<string, unknown> },
+      ctx
+    )
+  );
 
 // ---------------------------------------------------------------------------
 // Tools
@@ -71,21 +130,7 @@ tool(
       .length(1536)
       .describe("Pre-computed embedding vector (1536 dimensions)"),
     decisions: z
-      .array(
-        z.object({
-          decision_type: z.enum([
-            "classification",
-            "entity",
-            "reminder",
-            "tag",
-          ]),
-          value: z
-            .record(z.unknown())
-            .describe("Decision value (shape depends on decision_type)"),
-          confidence: z.number().min(0).max(1),
-          reasoning: z.string(),
-        })
-      )
+      .array(decisionEntrySchema)
       .describe("Decisions to attach to the thought"),
   }),
   async ({ content, session_id, created_by, embedding, decisions }) => {
@@ -247,15 +292,25 @@ tool(
 tool(
   "create_decision",
   "Add a decision to an existing thought.",
-  z.object({
-    thought_id: z.string().uuid(),
-    decision_type: z.enum(["classification", "entity", "reminder", "tag"]),
-    value: z
-      .record(z.unknown())
-      .describe("Decision value (shape depends on decision_type)"),
-    confidence: z.number().min(0).max(1),
-    reasoning: z.string(),
-  }),
+  z
+    .object({
+      thought_id: z.string().uuid(),
+      decision_type: z.enum(["classification", "entity", "reminder", "tag"]),
+      value: z
+        .record(z.unknown())
+        .describe("Decision value (shape depends on decision_type)"),
+      confidence: z.number().min(0).max(1),
+      reasoning: z.string(),
+    })
+    .superRefine((entry, ctx) =>
+      refineDecisionValue(
+        entry as {
+          decision_type: DecisionType;
+          value: Record<string, unknown>;
+        },
+        ctx
+      )
+    ),
   async (args) => {
     const { data, error } = await supabase
       .from("thought_decisions")
@@ -302,24 +357,53 @@ tool(
   }) => {
     const update: Record<string, unknown> = {};
     if (review_status !== undefined) update.review_status = review_status;
-    if (corrected_value !== undefined) update.corrected_value = corrected_value;
     if (corrected_by !== undefined) {
       update.corrected_by = corrected_by;
       update.corrected_at = new Date().toISOString();
     }
 
-    // Shallow-merge value patch: read current value, spread patch on top
-    if (value !== undefined) {
+    // Fetch current decision when we need decision_type (for validation) or value (for merge)
+    if (corrected_value !== undefined || value !== undefined) {
       const { data: current, error: fetchErr } = await supabase
         .from("thought_decisions")
-        .select("value")
+        .select("decision_type, value")
         .eq("id", decision_id)
         .single();
       if (fetchErr) return err(fetchErr.message);
-      update.value = {
-        ...(current.value as Record<string, unknown>),
-        ...value,
-      };
+
+      const dt = current.decision_type as DecisionType;
+      const schema = decisionValueSchemas[dt];
+
+      // Validate corrected_value against full schema
+      if (corrected_value !== undefined) {
+        const result = schema.safeParse(corrected_value);
+        if (!result.success) {
+          const issues = result.error.issues
+            .map((i) => `${i.message} at "${i.path.join(".")}"`)
+            .join("; ");
+          return err(
+            `Invalid corrected_value for ${dt}: ${issues}. Expected shape: ${formatShape(dt)}`
+          );
+        }
+        update.corrected_value = corrected_value;
+      }
+
+      // Validate value patch against partial schema (valid keys, correct types)
+      if (value !== undefined) {
+        const partialResult = schema.partial().strict().safeParse(value);
+        if (!partialResult.success) {
+          const issues = partialResult.error.issues
+            .map((i) => `${i.message} at "${i.path.join(".")}"`)
+            .join("; ");
+          return err(
+            `Invalid value patch for ${dt}: ${issues}. Expected shape: ${formatShape(dt)}`
+          );
+        }
+        update.value = {
+          ...(current.value as Record<string, unknown>),
+          ...value,
+        };
+      }
     }
 
     const { data, error } = await supabase

--- a/supabase/functions/mcp/tools_test.ts
+++ b/supabase/functions/mcp/tools_test.ts
@@ -698,6 +698,107 @@ Deno.test({
         }
       );
 
+      // ---- Decision value schema validation ----
+
+      await t.step(
+        "capture_thought rejects invalid tag value shape",
+        async () => {
+          const { parsed, isError } = await callTool("capture_thought", {
+            content: "Testing tag validation",
+            session_id: testSessionId,
+            created_by: testUserId,
+            embedding: dummyEmbedding(),
+            decisions: [
+              {
+                decision_type: "tag",
+                value: { tag: "urgent" }, // wrong key — should be { label: "..." }
+                confidence: 0.9,
+                reasoning: "test",
+              },
+            ],
+          });
+
+          assertEquals(isError, true);
+          assertExists(parsed.error);
+          const errorStr = JSON.stringify(parsed.error);
+          assertEquals(
+            errorStr.includes("label"),
+            true,
+            "Error should mention expected 'label' field"
+          );
+        }
+      );
+
+      await t.step(
+        "update_decision rejects invalid corrected_value for tag",
+        async () => {
+          const tagDecisionId = decisionIds[2]; // tag decision
+          const { parsed, isError } = await callTool("update_decision", {
+            decision_id: tagDecisionId,
+            review_status: "corrected",
+            corrected_value: { tag: "wrong-key" }, // wrong — should be { label: "..." }
+            corrected_by: testUserId,
+          });
+
+          assertEquals(isError, true);
+          assertExists(parsed.error);
+          const errorStr =
+            typeof parsed.error === "string"
+              ? parsed.error
+              : JSON.stringify(parsed.error);
+          assertEquals(
+            errorStr.includes("label"),
+            true,
+            "Error should mention expected 'label' field"
+          );
+        }
+      );
+
+      await t.step(
+        "update_decision rejects invalid value patch keys for reminder",
+        async () => {
+          const reminderId = decisionIds[3]; // reminder decision
+          const { parsed, isError } = await callTool("update_decision", {
+            decision_id: reminderId,
+            value: { due_att: "2026-05-01T10:00:00Z" }, // typo'd key
+          });
+
+          assertEquals(isError, true);
+          assertExists(parsed.error);
+          const errorStr =
+            typeof parsed.error === "string"
+              ? parsed.error
+              : JSON.stringify(parsed.error);
+          assertEquals(
+            errorStr.includes("due_at") || errorStr.includes("description"),
+            true,
+            "Error should mention valid fields for reminder"
+          );
+        }
+      );
+
+      await t.step(
+        "create_decision rejects invalid reminder value shape",
+        async () => {
+          const { parsed, isError } = await callTool("create_decision", {
+            thought_id: thoughtId,
+            decision_type: "reminder",
+            value: { when: "2026-05-01" }, // wrong — should be { due_at, description }
+            confidence: 0.8,
+            reasoning: "test",
+          });
+
+          assertEquals(isError, true);
+          assertExists(parsed.error);
+          const errorStr = JSON.stringify(parsed.error);
+          assertEquals(
+            errorStr.includes("due_at"),
+            true,
+            "Error should mention expected 'due_at' field"
+          );
+        }
+      );
+
       // ---- Unknown tool ----
 
       await t.step("tools/call returns error for unknown tool", async () => {


### PR DESCRIPTION
## Summary

Closes #56

- Add Zod `superRefine` validation to `capture_thought` and `create_decision` that cross-references `decision_type` with `value` shape, rejecting malformed values at the MCP boundary
- Add imperative validation in `update_decision` for `corrected_value` (full schema) and `value` patches (`schema.partial().strict()` — rejects unknown keys like typos)
- Fix naming inconsistencies in tool hints (`message`→`description` for reminders, `tag`→`label` for tags) and system prompt to align with canonical types in `packages/shared`
- Error messages include expected shape so the LLM can self-correct on retry

## Test plan

- [x] `capture_thought` rejects invalid tag value shape (`{ tag: "..." }` → expects `{ label: "..." }`)
- [x] `create_decision` rejects invalid reminder value shape (`{ when: "..." }` → expects `{ due_at, description }`)
- [x] `update_decision` rejects invalid `corrected_value` for tag
- [x] `update_decision` rejects invalid value patch keys for reminder (typo'd `due_att`)
- [x] All 26 MCP integration tests pass
- [x] All 56 agent unit tests pass
- [x] All 59 web tests pass
- [x] All 4 Playwright integration tests pass (`task test:integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)