### PR TITLE
Update docs to match current codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ A personal AI memory system where humans capture thoughts through a web app, and
 └──────┬───────┘                  └──┬───────┬───┘
        │ Supabase JS SDK             │       │
        │ (write messages,            │       │ MCP Client
-       │  subscribe to responses,    │       │ (@modelcontextprotocol/sdk)
+       │  subscribe to responses,    │       │ (Custom JSON-RPC)
        │  correct decisions)         │       │
        │                             │       │
        │    ┌───────────────┐        │       │
@@ -83,19 +83,19 @@ No `metadata` JSONB column. All structured data lives in `thought_decisions`.
 
 Every decision the agent makes, stored explicitly. One row per decision — a thought with three entities gets three separate decision rows, each with its own ID, confidence, and correction status.
 
-| Column            | Type             | Purpose                                       |
-| ----------------- | ---------------- | --------------------------------------------- |
-| `id`              | uuid             | PK                                            |
-| `thought_id`      | FK to thoughts   | Many decisions per thought                    |
-| `decision_type`   | text             | `classification`, `entity`, `reminder`, `tag` |
-| `value`           | jsonb            | Decision payload (see shapes below)           |
-| `confidence`      | float            | 0.0–1.0                                       |
-| `reasoning`       | text             | One sentence explaining why                   |
-| `review_status`   | text             | `pending`, `accepted`, `corrected`            |
-| `corrected_value` | jsonb            | Null until user overrides                     |
-| `corrected_by`    | FK to auth.users |                                               |
-| `corrected_at`    | timestamptz      |                                               |
-| `created_at`      | timestamptz      |                                               |
+| Column            | Type             | Purpose                                               |
+| ----------------- | ---------------- | ----------------------------------------------------- |
+| `id`              | uuid             | PK                                                    |
+| `thought_id`      | FK to thoughts   | Many decisions per thought                            |
+| `decision_type`   | text             | `classification`, `entity`, `reminder`, `tag`, `todo` |
+| `value`           | jsonb            | Decision payload (see shapes below)                   |
+| `confidence`      | float            | 0.0–1.0                                               |
+| `reasoning`       | text             | One sentence explaining why                           |
+| `review_status`   | text             | `pending`, `accepted`, `corrected`                    |
+| `corrected_value` | jsonb            | Null until user overrides                             |
+| `corrected_by`    | FK to auth.users |                                                       |
+| `corrected_at`    | timestamptz      |                                                       |
+| `created_at`      | timestamptz      |                                                       |
 
 Corrections are preserved alongside original decisions for the agent to learn from.
 
@@ -113,6 +113,9 @@ Corrections are preserved alongside original decisions for the agent to learn fr
 
 // tag — one decision per tag
 { "label": "urgent" }
+
+// todo — one per action item
+{ "description": "Call the plumber", "completed_at": null }
 ```
 
 **Categories** are freeform strings, not a fixed enum. The agent is instructed to prefer a seed list of common categories but can create new ones when nothing fits. The proactive reviewer consolidates duplicates over time.
@@ -163,6 +166,16 @@ Agent writes here, app reads here.
 `read_at` and `dismissed_at` are both kept — a notification can be seen but still in the list until explicitly cleared. Badge shows count where `read_at IS NULL`. List shows everything where `dismissed_at IS NULL`.
 
 > **Future enhancement:** Add external delivery channels (email, Slack webhook, Telegram bot) for time-sensitive reminders that need to reach users when the app isn't open. The `delivered_via` column supports this without schema changes.
+
+### `agent_state`
+
+Key-value store for agent process state. Used by the proactive reviewer to track its last run time.
+
+| Column       | Type        | Purpose                 |
+| ------------ | ----------- | ----------------------- |
+| `key`        | text        | PK                      |
+| `value`      | jsonb       | Arbitrary state payload |
+| `updated_at` | timestamptz |                         |
 
 ### `chat_sessions`
 
@@ -350,11 +363,10 @@ Creates `notification` rows (type = `reminder`, `decision_id` linked) for each m
 
 Two-pass approach to avoid sending all thoughts to the LLM:
 
-**Pass 1 — SQL candidate selection:**
+**Pass 1 — SQL candidate selection** (capped at 50 thoughts):
 
-- Low-confidence decisions: `WHERE confidence < 0.7 AND review_status = 'pending'`
-- Ungrouped thoughts: `WHERE id NOT IN (SELECT thought_id FROM thought_group_members)`
-- Recent corrections: `WHERE review_status = 'corrected' AND created_at > last_run`
+- Low-confidence decisions: `WHERE confidence < 0.7 AND review_status = 'pending'` (ordered by confidence ascending)
+- Corrected decisions: `WHERE review_status = 'corrected'` (fills remaining capacity, ordered by corrected_at descending)
 
 **Pass 2 — LLM processing** of candidates only:
 
@@ -419,13 +431,14 @@ OpenAI first (gpt-4o for reasoning, gpt-4o-mini as an option for cheaper calls l
 | **Chat**            | Main interface — session list sidebar + message area. Session created on "New Chat" click. |
 | **Notifications**   | List of reminders, suggestions, insights. Badge for unread.                                |
 | **Decision Review** | Browse decisions, filter by low confidence/pending, accept or correct                      |
+| **Reminders**       | Calendar month grid with reminder indicators, day detail view, month navigation            |
 
 ## Project Structure
 
 Monorepo with pnpm workspaces. Shared TypeScript types between web app and agent.
 
 ```
-open-brain/
+backup-brain/
 ├── packages/
 │   ├── web/          # Vite + React + TypeScript app
 │   ├── agent/        # Node.js + TypeScript agent process
@@ -437,7 +450,7 @@ open-brain/
 └── tsconfig.base.json
 ```
 
-The `shared` package contains database-facing types used by both web app and agent: `ChatSession`, `ChatMessage`, `Thought`, `ThoughtDecision`, `DecisionType`, `ThoughtGroup`, `Notification`. The `LLMProvider` interface lives in the `agent` package — only the agent calls LLMs.
+The `shared` package contains database-facing types used by both web app and agent: `ChatSession`, `ChatMessage`, `Thought`, `ThoughtDecision`, `DecisionType`, `DecisionValue`, `ReviewStatus`, `ThoughtGroup`, `ThoughtGroupMember`, `Notification`, `NotificationType`, `AgentState`. The `LLMProvider` interface lives in the `agent` package — only the agent calls LLMs.
 
 ## Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,19 @@ All commands use [go-task](https://taskfile.dev) (`task`). Binary versions manag
 ```bash
 task install              # pnpm install
 task dev                  # Start all dev servers (web + agent + edge functions)
+task dev:stop             # Kill all dev servers
 task typecheck            # Type-check all packages
+task lint                 # Lint all packages
+task test                 # Run all tests (agent + web + mcp)
 task test:agent           # Run agent tests (vitest)
 task test:web             # Run web tests (vitest)
 task test:mcp             # MCP integration tests (deno test, requires db:start + dev:functions)
+task test:integration     # End-to-end tests (Playwright, orchestrates full stack)
+task env                  # Write .env from local Supabase status
 task db:start             # Start local Supabase (Postgres, Auth, Realtime, Studio)
+task db:stop              # Stop local Supabase
 task db:reset             # Reset database (reapply all migrations)
+task db:dashboard         # Open Supabase Studio in browser
 task db:migration -- name # Create new migration file
 ```
 
@@ -56,7 +63,7 @@ Web App ←→ Supabase (DB + Realtime) ←→ Agent Process
 
 ### Database
 
-PostgreSQL 17 with pgvector extension. Schema in `supabase/migrations/`. Key tables: `chat_sessions`, `chat_messages`, `thoughts` (with 1536-dim embeddings), `thought_decisions`, `thought_groups`, `notifications`. RLS enabled. Similarity search via `match_thoughts()` PL/pgSQL function.
+PostgreSQL 17 with pgvector extension. Schema in `supabase/migrations/`. Key tables: `chat_sessions`, `chat_messages`, `thoughts` (with 1536-dim embeddings), `thought_decisions` (5 types: classification, entity, reminder, tag, todo), `thought_groups`, `notifications`, `agent_state`. RLS enabled. Similarity search via `match_thoughts()` PL/pgSQL function.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ The system is a **pnpm monorepo** with three packages plus Supabase infrastructu
 
 ### Key Design Decisions
 
-| Decision | Rationale |
-|----------|-----------|
-| Supabase as shared bus | Full decoupling between web and agent; works identically in local dev and cloud |
-| Thoughts are synthesized, not raw | Agent-distilled units are more searchable and meaningful than raw chat messages |
-| Decisions are first-class entities | Each classification, entity, reminder, and tag is stored with confidence, reasoning, and correction history |
-| Auto-settle everything | Zero friction by default; review is optional for users who want control |
-| Sequential per session, concurrent across | Prevents interleaving within a conversation while maximizing throughput |
+| Decision                                  | Rationale                                                                                                         |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Supabase as shared bus                    | Full decoupling between web and agent; works identically in local dev and cloud                                   |
+| Thoughts are synthesized, not raw         | Agent-distilled units are more searchable and meaningful than raw chat messages                                   |
+| Decisions are first-class entities        | Each classification, entity, reminder, tag, and todo is stored with confidence, reasoning, and correction history |
+| Auto-settle everything                    | Zero friction by default; review is optional for users who want control                                           |
+| Sequential per session, concurrent across | Prevents interleaving within a conversation while maximizing throughput                                           |
 
 ## Getting Started
 
@@ -95,7 +95,7 @@ task env
 task db:reset
 ```
 
-Add your OpenAI API key to `packages/agent/.env`:
+Add your OpenAI API key to `.env` at the monorepo root:
 
 ```
 OPENAI_API_KEY=sk-...
@@ -108,12 +108,12 @@ OPENAI_API_KEY=sk-...
 task dev
 ```
 
-| Service | URL |
-|---------|-----|
-| Web App | http://localhost:5173 |
-| Supabase Studio | http://localhost:54323 |
-| Agent Health | http://localhost:3001 |
-| MCP Server | http://localhost:54321/functions/v1/mcp |
+| Service         | URL                                     |
+| --------------- | --------------------------------------- |
+| Web App         | http://localhost:5173                   |
+| Supabase Studio | http://localhost:54323                  |
+| Agent Health    | http://localhost:3001                   |
+| MCP Server      | http://localhost:54321/functions/v1/mcp |
 
 ## Usage
 
@@ -122,6 +122,7 @@ Once running, open the web app and sign in. Start a conversation and tell it any
 > "We need to replace the roof before winter. Got a quote from ABC Roofing for $12k."
 
 The agent will:
+
 - Capture a thought about the roof replacement
 - Classify it under a category (e.g., Home Maintenance)
 - Extract entities (ABC Roofing)
@@ -139,12 +140,17 @@ The agent searches by meaning and retrieves the relevant thought, even if you do
 ```bash
 task install              # Install dependencies
 task dev                  # Start all dev servers
+task dev:stop             # Kill all dev servers
 task typecheck            # Type-check all packages
+task lint                 # Lint all packages
 task test                 # Run all tests
 task test:agent           # Agent tests (Vitest)
 task test:web             # Web tests (Vitest)
 task test:mcp             # MCP integration tests (Deno)
+task test:integration     # End-to-end tests (Playwright)
+task env                  # Write .env from local Supabase status
 task db:start             # Start local Supabase
+task db:stop              # Stop local Supabase
 task db:reset             # Reset database
 task db:dashboard         # Open Supabase Studio
 ```
@@ -157,32 +163,32 @@ pnpm -C packages/agent exec vitest run src/some-file.test.ts
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|-----------|
-| **Frontend** | React 19, Vite 8, Tailwind CSS 4, React Router 7, TanStack Query |
-| **Agent** | Node.js 22, OpenAI SDK (gpt-4o), node-cron |
-| **MCP Server** | Deno 2, Hono, Zod, Supabase Edge Functions |
-| **Database** | PostgreSQL 17, pgvector (1536-dim embeddings), Supabase Realtime |
-| **Embeddings** | OpenAI text-embedding-3-small |
-| **Infra** | AWS (S3 + CloudFront for web, App Runner for agent), Supabase Cloud |
-| **Dev Tools** | pnpm 10, mise, go-task, Vitest, Prettier, Husky, GitHub Actions |
+| Layer          | Technology                                                          |
+| -------------- | ------------------------------------------------------------------- |
+| **Frontend**   | React 19, Vite 8, Tailwind CSS 4, React Router 7, TanStack Query    |
+| **Agent**      | Node.js 22, OpenAI SDK (gpt-4o), node-cron                          |
+| **MCP Server** | Deno 2, Hono, Zod, Supabase Edge Functions                          |
+| **Database**   | PostgreSQL 17, pgvector (1536-dim embeddings), Supabase Realtime    |
+| **Embeddings** | OpenAI text-embedding-3-small                                       |
+| **Infra**      | AWS (S3 + CloudFront for web, App Runner for agent), Supabase Cloud |
+| **Dev Tools**  | pnpm 10, mise, go-task, Vitest, Prettier, Husky, GitHub Actions     |
 
 ### MCP Tools
 
 The MCP server exposes 10 tools via JSON-RPC:
 
-| Tool | Purpose |
-|------|---------|
-| `capture_thought` | Create a thought with decisions atomically |
-| `update_thought` | Modify thought content and re-embed |
-| `search_thoughts` | Semantic similarity search |
-| `list_thoughts` | Browse/filter thoughts |
-| `create_decision` | Add a decision to a thought |
-| `update_decision` | Accept, correct, or patch a decision |
-| `list_decisions` | Query decisions with filters |
-| `create_group` | Create a thought group |
-| `create_notification` | Surface a reminder/suggestion/insight |
-| `set_session_title` | Set chat session title |
+| Tool                  | Purpose                                    |
+| --------------------- | ------------------------------------------ |
+| `capture_thought`     | Create a thought with decisions atomically |
+| `update_thought`      | Modify thought content and re-embed        |
+| `search_thoughts`     | Semantic similarity search                 |
+| `list_thoughts`       | Browse/filter thoughts                     |
+| `create_decision`     | Add a decision to a thought                |
+| `update_decision`     | Accept, correct, or patch a decision       |
+| `list_decisions`      | Query decisions with filters               |
+| `create_group`        | Create a thought group                     |
+| `create_notification` | Surface a reminder/suggestion/insight      |
+| `set_session_title`   | Set chat session title                     |
 
 ## Project Structure
 
@@ -191,10 +197,9 @@ backup-brain/
 ├── packages/
 │   ├── web/                # React + Vite frontend
 │   │   └── src/
-│   │       ├── views/      # Login, chat, decision review, notifications
-│   │       ├── components/ # Chat view, session list, UI primitives
-│   │       ├── hooks/      # Auth, sessions, queries
-│   │       └── lib/        # Supabase client, utilities
+│   │       ├── app/        # App shell, routes, layouts, page wrappers
+│   │       ├── features/   # auth, chat, decisions, notifications, reminders
+│   │       └── shared/     # Reusable UI primitives, Supabase client, utilities
 │   ├── agent/              # Node.js agent process
 │   │   └── src/
 │   │       ├── index.ts              # Entry point
@@ -217,33 +222,34 @@ backup-brain/
 
 ### Agent
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `SUPABASE_URL` | Yes | Supabase project URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Service role key (bypasses RLS) |
-| `OPENAI_API_KEY` | Yes | OpenAI API key |
-| `MCP_URL` | No | MCP server URL (default: local) |
-| `HEALTH_PORT` | No | Health check port (default: 3001) |
+| Variable                    | Required | Description                       |
+| --------------------------- | -------- | --------------------------------- |
+| `SUPABASE_URL`              | Yes      | Supabase project URL              |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes      | Service role key (bypasses RLS)   |
+| `OPENAI_API_KEY`            | Yes      | OpenAI API key                    |
+| `MCP_URL`                   | No       | MCP server URL (default: local)   |
+| `HEALTH_PORT`               | No       | Health check port (default: 3001) |
 
 ### Web
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `VITE_SUPABASE_URL` | Yes | Supabase project URL |
-| `VITE_SUPABASE_ANON_KEY` | Yes | Supabase anonymous key |
+| Variable                 | Required | Description            |
+| ------------------------ | -------- | ---------------------- |
+| `VITE_SUPABASE_URL`      | Yes      | Supabase project URL   |
+| `VITE_SUPABASE_ANON_KEY` | Yes      | Supabase anonymous key |
 
 ## Database
 
 PostgreSQL 17 with the **pgvector** extension for semantic search. Key tables:
 
-| Table | Purpose |
-|-------|---------|
-| `chat_sessions` | Conversation sessions |
-| `chat_messages` | Messages (user and assistant) |
-| `thoughts` | Agent-synthesized memories with 1536-dim vector embeddings |
-| `thought_decisions` | Classifications, entities, reminders, tags with confidence scores |
-| `thought_groups` | Clusters of related thoughts |
-| `notifications` | Reminders, suggestions, and insights |
+| Table               | Purpose                                                                  |
+| ------------------- | ------------------------------------------------------------------------ |
+| `chat_sessions`     | Conversation sessions                                                    |
+| `chat_messages`     | Messages (user and assistant)                                            |
+| `thoughts`          | Agent-synthesized memories with 1536-dim vector embeddings               |
+| `thought_decisions` | Classifications, entities, reminders, tags, todos with confidence scores |
+| `thought_groups`    | Clusters of related thoughts                                             |
+| `notifications`     | Reminders, suggestions, and insights                                     |
+| `agent_state`       | Key-value store for agent process state                                  |
 
 Similarity search is powered by the `match_thoughts()` PL/pgSQL function using cosine distance.
 

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -21,7 +21,7 @@ From monorepo root: `task test:web`
 Layout routes in `App.tsx`:
 
 - **Auth layout** (minimal, no shell): `/login` -> `LoginView`
-- **App layout** (full shell, protected): `/chat`, `/chat/:sessionId`, `/review`, `/notifications`
+- **App layout** (full shell, protected): `/chat`, `/chat/:sessionId`, `/review`, `/notifications`, `/reminders`
 - `/` and `*` redirect to `/chat`
 
 `ProtectedRoute` checks `useAuth()` and redirects unauthenticated users to `/login`.


### PR DESCRIPTION
## Summary

- Add `todo` decision type across CLAUDE.md, ARCHITECTURE.md, and README.md
- Add `agent_state` table to schema documentation
- Add Reminders view to web app views
- Add missing task commands (`dev:stop`, `lint`, `test:integration`, `env`, `db:stop`, `db:dashboard`)
- Fix incorrect `.env` path in README setup instructions (was `packages/agent/.env`, now monorepo root)
- Fix stale web `src/` folder structure in README (was `views/components/hooks/lib`, now `app/features/shared`)
- Fix proactive reviewer Pass 1 description to match implementation (remove nonexistent "ungrouped thoughts" query)
- Fix MCP client label in architecture diagram (`@modelcontextprotocol/sdk` → `Custom JSON-RPC`)
- Fix project directory name (`open-brain/` → `backup-brain/`)
- Update shared types list to match actual exports

## Test plan

- [x] All tests pass (verified by pre-commit hooks)
- [ ] Review each file for accuracy against codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)